### PR TITLE
Fin 27 login

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,6 @@ next router를 사용해 각 동물 카드를 클릭하면 해당 동물의 상�
 #### 23/04/05
 <img src="./public/images/yr.jpeg" style="width:24px; height:24px; border-radius: 50%;"> 필터 기능을 구현하였습니다. [ant design dropdown](https://ant.design/components/dropdown), [ant design select](https://ant.design/components/select)에 커스텀 UI를 접목하여 사용자가 선택한 필터로 api 쿼리를 할 수 있게 제공하였습니다.<br/>
 리스트/카드 뷰를 오갈 수 있는 버튼을 추가해 UX를 개선했습니다.
+
+#### 23/04/07
+<img src="./public/images/sh.jpeg" style="width:24px; height:24px; border-radius: 50%;"> 로그인 기능, withAuth, localstorage를 통한 페이지별 접근 관리 기능(이후 refresh로 변경예정), 로그인 모달, 회원가입 모달 => 페이지로 변경.

--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ next router를 사용해 각 동물 카드를 클릭하면 해당 동물의 상�
 리스트/카드 뷰를 오갈 수 있는 버튼을 추가해 UX를 개선했습니다.
 
 #### 23/04/07
-<img src="./public/images/sh.jpeg" style="width:24px; height:24px; border-radius: 50%;"> 로그인 기능, withAuth, localstorage를 통한 페이지별 접근 관리 기능(이후 refresh로 변경예정), 로그인 모달, 회원가입 모달 => 페이지로 변경.
+<img src="./public/images/sh.jpeg" style="width:24px; height:24px; border-radius: 50%;"> 로그인 기능, withAuth, localstorage를 통한 페이지별 접근 관리 기능(이후 refresh로 변경예정), 브라우저 새로고침할때 토큰 확인하여 로그인 유지시키는 기능, 로그인 모달 및 회원가입 모달 => 페이지로 변경.

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,0 +1,5 @@
+import LoginForm from "@/components/units/loginForm";
+
+export default function SignUpPage() {
+  return <LoginForm />;
+}

--- a/src/commons/apollo/index.tsx
+++ b/src/commons/apollo/index.tsx
@@ -1,16 +1,27 @@
 import { ApolloProvider, ApolloClient, InMemoryCache, ApolloLink } from "@apollo/client";
 import { createUploadLink } from "apollo-upload-client";
+import { useEffect } from "react";
+import { useRecoilState } from "recoil";
+import { accessTokenState } from "../store";
 
 interface IApolloSettingProps {
   children: JSX.Element;
 }
-
 const GLOBAL_STATE = new InMemoryCache();
 
 export default function ApolloSetting(props: IApolloSettingProps) {
+  const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
+
+  useEffect(() => {
+    const result = localStorage.getItem("accessToken");
+    console.log(result);
+    if (result) setAccessToken(result);
+  }, []);
+
   const uploadLink = createUploadLink({
-    uri: "http://backendonline.codebootcamp.co.kr/graphql"
-  })
+    uri: "http://backendonline.codebootcamp.co.kr/graphql",
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
   
   const client = new ApolloClient({
     link: ApolloLink.from([uploadLink]),

--- a/src/commons/hocs/index.tsx
+++ b/src/commons/hocs/index.tsx
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+
+export const withAuth = (Component: any) => (props: any) => {
+    const router = useRouter();
+
+    useEffect(() => {
+        if(!localStorage.getItem("accessToken")) {
+            alert("로그인 후 이용 가능합니다.");
+            void router.push("/");
+        }; 
+    }, []);
+
+    return <Component {...props} />
+}

--- a/src/commons/layout/header/index.tsx
+++ b/src/commons/layout/header/index.tsx
@@ -1,9 +1,6 @@
-import {useState} from "react";
 import styled from "@emotion/styled";
-import {Modal, Button} from "antd";
-import LoginForm from "@/components/units/LoginForm";
-import SignupForm from "@/components/units/SignupForm";
-import {useRouter} from "next/router";
+import {Button} from "antd";
+import Link from "next/link";
 
 const Wrapper = styled.div`
   width: 100%;
@@ -11,21 +8,6 @@ const Wrapper = styled.div`
 `;
 
 export default function LayoutHeader() {
-  const router = useRouter();
-  const [openLogin, setOpenLogin] = useState(false);
-  const [openSignUp, setOpenSignUp] = useState(false);
-
-  const loginModal = () => {
-    setOpenLogin((prev) => !prev);
-  };
-
-  const signUpModal = () => {
-    setOpenSignUp((prev) => !prev);
-  };
-
-  const handleClickLogo = () => {
-    void router.push("/");
-  };
 
   return (
     <Wrapper>
@@ -39,34 +21,10 @@ export default function LayoutHeader() {
           alignItems: "center",
         }}
       >
-        <h1 onClick={handleClickLogo} style={{cursor: "pointer"}}>
-          유기동물보호센터
-        </h1>
+        <Link href="/"><h1 style={{cursor: "pointer"}}>유기동물보호센터</h1></Link>
         <div>
-          <Button onClick={loginModal} style={{marginRight: "0.5rem"}}>
-            로그인
-          </Button>
-          {openLogin && (
-            <Modal
-              open={true}
-              onOk={loginModal}
-              onCancel={loginModal}
-              footer={[]}
-            >
-              <LoginForm />
-            </Modal>
-          )}
-          <Button onClick={signUpModal}>회원가입</Button>
-          {openSignUp && (
-            <Modal
-              open={true}
-              onOk={signUpModal}
-              onCancel={signUpModal}
-              footer={[]}
-            >
-              <SignupForm />
-            </Modal>
-          )}
+          <Link href="/login"><Button style={{marginRight: "0.5rem"}}>로그인</Button></Link>
+          <Link href="/signup"><Button>회원가입</Button></Link>
         </div>
       </div>
     </Wrapper>

--- a/src/commons/layout/header/index.tsx
+++ b/src/commons/layout/header/index.tsx
@@ -1,14 +1,40 @@
+import { gql, useQuery } from "@apollo/client";
 import styled from "@emotion/styled";
 import {Button} from "antd";
 import Link from "next/link";
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
 
 const Wrapper = styled.div`
   width: 100%;
   height: 5rem;
 `;
 
-export default function LayoutHeader() {
+const FETCH_USER_LOGGED_IN = gql`
+    query fetchUserLoggedIn {
+        fetchUserLoggedIn {
+            _id
+            email
+            name
+        }
+    }
+`
 
+export default function LayoutHeader() {
+  const [info, setInfo] = useState(false);
+  // const { data } = useQuery(FETCH_USER_LOGGED_IN);
+  
+  useEffect(() => {
+    if(localStorage.getItem("accessToken")) {
+        setInfo(true);
+    }; 
+  });
+
+  const onClickLogout = () => {
+    localStorage.removeItem("accessToken")
+    setInfo(false);
+  }
+  
   return (
     <Wrapper>
       <div
@@ -23,8 +49,20 @@ export default function LayoutHeader() {
       >
         <Link href="/"><h1 style={{cursor: "pointer"}}>유기동물보호센터</h1></Link>
         <div>
-          <Link href="/login"><Button style={{marginRight: "0.5rem"}}>로그인</Button></Link>
-          <Link href="/signup"><Button>회원가입</Button></Link>
+          {info
+            ? (
+              <>
+                <Button style={{marginRight: "0.5rem"}} onClick={onClickLogout}>로그아웃</Button>
+                <Link href="/"><Button>마이페이지</Button></Link>
+              </> 
+            ) : (
+              <>
+                <Link href="/login"><Button style={{marginRight: "0.5rem"}}>로그인</Button></Link>
+                <Link href="/signup"><Button>회원가입</Button></Link>
+              </>
+            )
+          }
+          
         </div>
       </div>
     </Wrapper>

--- a/src/commons/store/index.ts
+++ b/src/commons/store/index.ts
@@ -4,3 +4,8 @@ export const viewTypeState = atom({
   key: "viewTypeState",
   default: "list",
 });
+
+export const accessTokenState = atom({
+  key: "accessTokenState",
+  default: "",
+})

--- a/src/components/units/loginForm.tsx
+++ b/src/components/units/loginForm.tsx
@@ -43,24 +43,26 @@ export default function LoginForm() {
 
   const onClickLogin = async () => {
     try {
-      const reuslt = await loginUser({
-          variables: {
-              email,
-              password
-          },
-      })
-      const accessToken = reuslt.data?.loginUser.accessToken;
-      console.log(accessToken);
-      if(!accessToken) {
-          console.error("로그인에 실패")
-      }
-      setAccessToken(accessToken);
+        const reuslt = await loginUser({
+            variables: {
+                email,
+                password
+            },
+        })
+        const accessToken = reuslt.data?.loginUser.accessToken;
+        console.log(accessToken);
+        if(!accessToken) {
+            console.error("로그인에 실패")
+        }
+        setAccessToken(accessToken);
+        localStorage.setItem("accessToken", accessToken);
 
-      void router.push("/");
-  } catch (error) {
-      console.log(error);
-  }
-  };
+        void router.push("/");
+
+    } catch (error) {
+        console.log(error);
+    }
+}
 
   return (
     <Wrapper>

--- a/src/components/units/loginForm.tsx
+++ b/src/components/units/loginForm.tsx
@@ -1,61 +1,98 @@
-import React, {useState, useCallback} from "react";
-import {Form, Input, Button} from "antd";
+import React, {ChangeEvent, useState} from "react";
+import {Input, Button} from "antd";
 import styled from "@emotion/styled";
+import { useRouter } from "next/router";
+import { useRecoilState } from "recoil";
+import { accessTokenState } from "@/commons/store";
+import { gql, useMutation } from "@apollo/client";
+
+const LOGIN_USER = gql`
+    mutation loginUser($email: String!, $password: String!){
+        loginUser(email: $email, password: $password){
+            accessToken
+        }
+    }
+`
 
 const ButtonWrapper = styled.div`
   margin-top: 10px;
 `;
 
-const FormWrapper = styled(Form)`
+const FormWrapper = styled.div`
   padding: 10px;
 `;
 
+const Wrapper = styled.div`
+  width: 500px;
+`;
+
 export default function LoginForm() {
+  const router = useRouter();
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [accessToken, setAccessToken] = useRecoilState(accessTokenState);
+  const [loginUser] = useMutation(LOGIN_USER);
 
-  const onChangeEmail = (e: any) => {
+  const onChangeEmail = (e: ChangeEvent<HTMLInputElement>) => {
     setEmail(e.target.value);
   };
 
-  const onChangePassword = (e: any) => {
+  const onChangePassword = (e: ChangeEvent<HTMLInputElement>) => {
     setPassword(e.target.value);
   };
 
-  const onSubmitForm = useCallback(() => {
-    console.log(email, password);
-  }, [email, password]);
+  const onClickLogin = async () => {
+    try {
+      const reuslt = await loginUser({
+          variables: {
+              email,
+              password
+          },
+      })
+      const accessToken = reuslt.data?.loginUser.accessToken;
+      console.log(accessToken);
+      if(!accessToken) {
+          console.error("로그인에 실패")
+      }
+      setAccessToken(accessToken);
+
+      void router.push("/");
+  } catch (error) {
+      console.log(error);
+  }
+  };
 
   return (
-    <FormWrapper onFinish={onSubmitForm}>
-      <div>
-        <label htmlFor="user-email">이메일</label>
-        <br />
-        <Input
-          name="user-email"
-          type="email"
-          value={email}
-          onChange={onChangeEmail}
-          required
-        />
-      </div>
-      <div>
-        <label htmlFor="user-password">패스워드</label>
-        <br />
-        <Input
-          name="user-password"
-          type="password"
-          value={password}
-          onChange={onChangePassword}
-          required
-        />
-      </div>
-      <ButtonWrapper>
-        <Button type="primary" htmlType="submit">
-          로그인
-        </Button>
-        {/* 회원가입버튼 추가가능 */}
-      </ButtonWrapper>
-    </FormWrapper>
+    <Wrapper>
+      <FormWrapper>
+        <div>
+          <label htmlFor="user-email">이메일</label>
+          <br />
+          <Input
+            name="user-email"
+            type="email"
+            value={email}
+            onChange={onChangeEmail}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="user-password">패스워드</label>
+          <br />
+          <Input
+            name="user-password"
+            type="password"
+            value={password}
+            onChange={onChangePassword}
+            required
+          />
+        </div>
+        <ButtonWrapper>
+          <Button type="primary" htmlType="submit" onClick={onClickLogin}>
+            로그인
+          </Button>
+        </ButtonWrapper>
+      </FormWrapper>
+    </Wrapper>
   );
 }

--- a/src/components/units/signUpForm.tsx
+++ b/src/components/units/signUpForm.tsx
@@ -1,5 +1,6 @@
 import React, {useState, useCallback} from "react";
 import {Form, Input, Checkbox, Button} from "antd";
+import styled from "@emotion/styled";
 
 export default function SignupForm() {
   // 필요한 기능 : 로그인시 해당 페이지 접속 불가하게
@@ -49,8 +50,12 @@ export default function SignupForm() {
     console.log(email, nickname, password);
   }, [email, password, passwordCheck, term]);
 
+  const Wrapper = styled.div`
+    width: 500px;
+  `
+
   return (
-    <>
+    <Wrapper>
       <Form onFinish={onSubmit} style={{padding: 10}}>
         <div>
           <label htmlFor="user-email">아이디</label>
@@ -112,6 +117,6 @@ export default function SignupForm() {
           </Button>
         </div>
       </Form>
-    </>
+    </Wrapper>
   );
 }


### PR DESCRIPTION
로그인 기능, withAuth, localstorage를 통한 페이지별 접근 관리 기능(이후 refresh로 변경예정), 브라우저 새로고침할때 토큰 확인하여 로그인 유지시키는 기능, 로그인 모달 및 회원가입 모달 => 페이지로 변경.

개인 브랜치에 main을 덮어씌우는 일이 잦아져서 일단 잘 되는 기능만 푸쉬합니다.
이후 추가할 기능
- 로그인시 표시되는 개인 항목들
- 마이페이지
- 회원 아닐시 접근불가 페이지 설정
- 회원가입, 로그인창 디자인
- container, presenter 나누기